### PR TITLE
Devops/#87 coverage reports

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -79,6 +79,36 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+				<configuration>
+					<includes>
+					<include>**/*Tests.java</include>
+					</includes>
+				</configuration>
+			</plugin>
+			<!-- This plugin generate a coverage file located at target/site/jacoco/jacoco.xml-->
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.7</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.8.1",
         "@emotion/styled": "^11.8.1",
+        "@mui/icons-material": "^5.5.0",
         "@mui/material": "^5.4.4",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
@@ -21,6 +22,8 @@
         "autoprefixer": "^10.4.2",
         "mui": "0.0.1",
         "postcss": "^8.4.7",
+        "prettier": "^2.5.1",
+        "prettier-plugin-tailwindcss": "^0.1.8",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router": "^6.2.2",
@@ -2940,6 +2943,31 @@
         "@types/react": "^16.8.6 || ^17.0.0",
         "react": "^17.0.0",
         "react-dom": "^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.5.1.tgz",
+      "integrity": "sha512-40f68p5+Yhq3dCn3QYHqQt5RETPyR3AkDw+fma8PtcjqvZ+d+jF84kFmT6NqwA3he7TlwluEtkyAmPzUE4uPdA==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^17.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -13240,6 +13268,28 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.8.tgz",
+      "integrity": "sha512-hwarSBCswAXa+kqYtaAkFr3Vop9o04WOyZs0qo3NyvW8L7f1rif61wRyq0+ArmVThOuRBcJF5hjGXYk86cwemg==",
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -18555,6 +18605,14 @@
         "clsx": "^1.1.1",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2"
+      }
+    },
+    "@mui/icons-material": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.5.1.tgz",
+      "integrity": "sha512-40f68p5+Yhq3dCn3QYHqQt5RETPyR3AkDw+fma8PtcjqvZ+d+jF84kFmT6NqwA3he7TlwluEtkyAmPzUE4uPdA==",
+      "requires": {
+        "@babel/runtime": "^7.17.2"
       }
     },
     "@mui/material": {
@@ -25871,6 +25929,17 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg=="
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.8.tgz",
+      "integrity": "sha512-hwarSBCswAXa+kqYtaAkFr3Vop9o04WOyZs0qo3NyvW8L7f1rif61wRyq0+ArmVThOuRBcJF5hjGXYk86cwemg==",
+      "requires": {}
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "coverage": "react-scripts test --env=jsdom --watchAll=false --coverage",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
  ## Changes
  - Added coverage report to backend code
  ![Captura de pantalla de 2022-03-14 23-01-04](https://user-images.githubusercontent.com/72742676/158275618-5490d56d-4cec-4aba-b473-d73930d34a80.png)
  - Added coverage report script to frontend code
![Captura de pantalla de 2022-03-15 00-12-40](https://user-images.githubusercontent.com/72742676/158275695-f1019589-d489-4ff1-be4f-7dca46b3e130.png)
These files will be sent once codacy is configured

  ## Steps to review
- Backend: ```mvn verify``` the report should be at backend/target/site/jacoco/index.html
- Frontend: ```npm run coverage``` the report should be at frontend/coverage/lcov-report/index.html