### PR TITLE
#197: implement profile page and tabs

### DIFF
--- a/frontend/src/components/molecules/TabPanel/tabPanel.tsx
+++ b/frontend/src/components/molecules/TabPanel/tabPanel.tsx
@@ -1,0 +1,25 @@
+import { Box } from "@mui/material";
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+const TabPanel = (props: TabPanelProps) => {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+    </div>
+  );
+};
+
+export default TabPanel;

--- a/frontend/src/components/molecules/TabPanel/tabPanel.tsx
+++ b/frontend/src/components/molecules/TabPanel/tabPanel.tsx
@@ -1,7 +1,9 @@
+import { ReactNode } from "react";
+
 import { Box } from "@mui/material";
 
 interface TabPanelProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
   index: number;
   value: number;
 }

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -7,6 +7,8 @@ import EventCard from "./Cards/eventCard";
 import LocationCard from "./Cards/locationCard";
 import UserHorizontalCard from "./Cards/userHorizontalCard";
 
+import TabPanel from "./TabPanel/tabPanel";
+
 export {
   Accept,
   SwipeableDrawer,
@@ -14,4 +16,5 @@ export {
   EventCard,
   UserHorizontalCard,
   LocationCard,
+  TabPanel,
 };

--- a/frontend/src/components/organisms/index.ts
+++ b/frontend/src/components/organisms/index.ts
@@ -1,8 +1,11 @@
 import ModalDrawer from "./ModalDrawer/modalDrawer";
+
 import ParticipateForm from "../organisms/forms/participateForm";
 import SponsorshipForm from "./forms/sponsorshipForm";
 import HostingForm from "./forms/hostingForm";
 import EventForm from "./forms/eventForm";
+
+import ProfileInfoTab from "./tabs/profileInfo";
 
 export {
   ModalDrawer,
@@ -10,4 +13,5 @@ export {
   HostingForm,
   SponsorshipForm,
   EventForm,
+  ProfileInfoTab,
 };

--- a/frontend/src/components/organisms/tabs/profileInfo.tsx
+++ b/frontend/src/components/organisms/tabs/profileInfo.tsx
@@ -1,0 +1,5 @@
+const ProfileInfoTab = () => {
+  return <section>TODO: ProfileInfoTab</section>;
+};
+
+export default ProfileInfoTab;

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -10,10 +10,13 @@ import EventDetailPage from "./events/eventDetails";
 import LocationDetailPage from "./locations/locationDetails";
 import LocationListPage from "./locations/locations";
 
+import ProfilePage from "./profile/profile";
+
 export {
   AppHeader,
   LandingPage,
   AppFooter,
+  ProfilePage,
   EventListPage,
   EventDetailPage,
   NewEventPage,

--- a/frontend/src/pages/profile/profile.tsx
+++ b/frontend/src/pages/profile/profile.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+
+import { useNavigate, useParams } from "react-router";
+import { Box, Tab, Tabs } from "@mui/material";
+import { Event, Info, LocationCity, Receipt } from "@mui/icons-material";
+
+import { TabPanel } from "components/molecules";
+import { ProfileInfoTab } from "components/organisms";
+import Page from "../page";
+
+const tabs = {
+  events: 0,
+  locations: 1,
+  tickets: 2,
+  info: 3,
+};
+
+const ProfilePage = () => {
+  const activeTabName =
+    useParams<{ tab: "events" | "locations" | "tickets" | "info" }>().tab;
+  const navigate = useNavigate();
+
+  const activeTabIndex = useMemo(() => {
+    return tabs[activeTabName || "events"];
+  }, [activeTabName]);
+
+  const handleChange = (event: React.SyntheticEvent, index: number) => {
+    navigate(`/profile/${Object.keys(tabs)[index]}`);
+  };
+
+  return (
+    <Page title="Mi Perfil">
+      <Box className="mt-5" sx={{ borderBottom: 1, borderColor: "divider" }}>
+        <Tabs
+          value={activeTabIndex}
+          onChange={handleChange}
+          aria-label="basic tabs example"
+        >
+          <Tab icon={<Event />} />
+          <Tab icon={<LocationCity />} />
+          <Tab icon={<Receipt />} />
+          <Tab icon={<Info />} />
+        </Tabs>
+      </Box>
+      <TabPanel value={activeTabIndex} index={0}>
+        TODO: Mis Eventos
+      </TabPanel>
+      <TabPanel value={activeTabIndex} index={1}>
+        TODO: Mis Ubicaciones
+      </TabPanel>
+      <TabPanel value={activeTabIndex} index={2}>
+        TODO: Mis Tickets
+      </TabPanel>
+      <TabPanel value={activeTabIndex} index={3}>
+        TODO: Mis Datos
+        <ProfileInfoTab />
+      </TabPanel>
+    </Page>
+  );
+};
+
+export default ProfilePage;

--- a/frontend/src/pages/profile/profile.tsx
+++ b/frontend/src/pages/profile/profile.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { SyntheticEvent, useMemo } from "react";
 
 import { useNavigate, useParams } from "react-router";
 import { Box, Tab, Tabs } from "@mui/material";
@@ -24,8 +24,8 @@ const ProfilePage = () => {
     return tabs[activeTabName || "events"];
   }, [activeTabName]);
 
-  const handleChange = (event: React.SyntheticEvent, index: number) => {
-    navigate(`/profile/${Object.keys(tabs)[index]}`);
+  const handleChange = (event: SyntheticEvent, index: number) => {
+    navigate(`/profile/${Object.keys(tabs)?.[index] || "events"}`);
   };
 
   return (

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -33,13 +33,21 @@ const AppRoutes = () => {
           <Routes>
             <Route path="/landing" element={<LandingPage />} />
             <Route path="/test" element={<TestPage />} />
+
             <Route path="/events" element={<EventListPage />} />
             <Route path="/events/new" element={<NewEventPage />} />
             <Route path="/events/:id" element={<EventDetailPage />} />
+
             <Route path="/locations" element={<LocationListPage />} />
             <Route path="/locations/new" element={<NewLocationPage />} />
             <Route path="/locations/:id" element={<LocationDetailPage />} />
+
             <Route path="/profile/:tab" element={<ProfilePage />} />
+            <Route
+              path="/profile"
+              element={<Navigate to="/profile/events" />}
+            />
+
             <Route path="*" element={<Navigate to="/landing" />} />
           </Routes>
         </Router>

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -15,6 +15,7 @@ import {
   LocationListPage,
   LandingPage,
   TestPage,
+  ProfilePage,
 } from "pages";
 import NewLocationPage from "pages/locations/newLocation";
 
@@ -38,6 +39,7 @@ const AppRoutes = () => {
             <Route path="/locations" element={<LocationListPage />} />
             <Route path="/locations/new" element={<NewLocationPage />} />
             <Route path="/locations/:id" element={<LocationDetailPage />} />
+            <Route path="/profile/:tab" element={<ProfilePage />} />
             <Route path="*" element={<Navigate to="/landing" />} />
           </Routes>
         </Router>


### PR DESCRIPTION
closes #197 

## changes

- profile page added and routed
- tab routing is added
- tab panel component is added
- profile info tab created as example

## steps to review

- check the `/profile` page
- check the tabs, redirection ...
- check the implementation and take it as the base in order to add tabs