### PR TITLE
hotfix: avoid stripe transaction when price is 0

### DIFF
--- a/backend/src/main/java/com/eventus/backend/services/HostingService.java
+++ b/backend/src/main/java/com/eventus/backend/services/HostingService.java
@@ -116,7 +116,9 @@ public class HostingService implements IHostingService {
         Validate.isTrue(hosting.getEvent() != null && (hosting.getLocation().getOwner().getId().equals(user.getId()) || user.isAdmin()),"No eres el dueño del evento");
         Boolean paid = false;
         if(b){
+            if(hosting.getPrice()>=0.5){
             stripeService.createHostingPayment(hosting);
+            }
             paid = true;
         }
         if(paid) hosting.setAccepted(true);

--- a/backend/src/main/java/com/eventus/backend/services/ParticipationService.java
+++ b/backend/src/main/java/com/eventus/backend/services/ParticipationService.java
@@ -53,8 +53,10 @@ public class ParticipationService implements IParticipationService{
         participation.setPrice(event.getPrice());
         participation.setEvent(event);
         participation.setUser(user);
-        PaymentIntent payment = stripeService.createParticipationPayment(participation);
-        if(payment != null) partRepository.save(participation);
+        if(event.getPrice()>=0.5){
+            stripeService.createParticipationPayment(participation);
+        }
+        partRepository.save(participation);
     }
     
     public Participation createParticipationAndTicket(Event event, User user) throws DocumentException, IOException, DataAccessException, StripeException {

--- a/backend/src/main/java/com/eventus/backend/services/SponsorshipService.java
+++ b/backend/src/main/java/com/eventus/backend/services/SponsorshipService.java
@@ -97,7 +97,9 @@ public class SponsorshipService implements ISponsorshipService{
         Validate.isTrue(sponsor.getEvent().getOrganizer().getId().equals(user.getId())||user.isAdmin(),"Debes ser el organizador del evento");
         Boolean paid = false;
         if(b){
+            if(sponsor.getQuantity()>=0.5){
             stripeService.createSponsorshipPayment(sponsor);
+            }
             paid = true;
         }
         if(paid) sponsor.setAccepted(true);


### PR DESCRIPTION
Added a validation to avoid transactions when any Participation, Hosting or Sponsor price is less than 0.5. This has been added due to Stripe only accepts transactions over 0.5 to get its commission.